### PR TITLE
(MKD) - Adds an initial paragraph in Drupal Sevilla's description

### DIFF
--- a/content/comunidades/Drupal Sevilla.md
+++ b/content/comunidades/Drupal Sevilla.md
@@ -2,9 +2,27 @@
 title: 'Drupal Sevilla'
 ---
 
-Andalûh (EPA) / Andaluz (EPA) / Andalusian (Proposal)
+Ficha de presentación de la comunidad local Drupal Sevilla, grupo de personas interesadas en Drupal.  
+
+**Nombre**: Drupal Sevilla  
+**Fecha de inicio (aprox.):** Octubre 2011, [DrupalCamp Spain - Sevilla 2011](https://2011.drupalcamp.es/)  
+**Ubicación:** Aleatoria, al margen de empresas y sedes. Cada cita en un lugar distinto.  
+**Media de asistencia:** 10 - 15 personas.  
+**Periodicidad ideal:** Mensual.  
+**Keywords:** Drupal, PHP, Symfony, Drush, Drupal Console, Composer.   
+
+
+Dêccrîççión / Descripción / Description  
+--------------------------------------------
+[1- Andalûh (EPA) / Andaluz (EPA) / Andalusian (Proposal)](#-1--andalh-epa--andaluz-epa--andalusian-proposal)
+[2- Câtteyano / Castellano / Castilian (Spanish from Spain)](#-2--ctteyano--castellano--castilian-spanish-from-spain)
+[3- Inglêh / Inglés / English](#-3--inglh--ingls--english)
+
+
+
+## 1- Andalûh (EPA) / Andaluz (EPA) / Andalusian (Proposal)
 -----------------------------------------------------
-Ola, biembenío y biembenía. Êtta êh la fixa de preçentaçión der grupo locâh de Drupâh Çebiya, una reunión periódica o aleatoria (çegún la época) de perçonâ intereçâh en tó lo que rodea al aprendiçahe y êpperiençiâ con diberçâ tênnolohíâ relaçionâh con Drupâh en particulâh: pp, Twîh, Symfony, Compoçêh... nô reunimô en çitiô cambiantê (cá quedá en un lugâh diferente), por aqueyo de deçacoplâh comunidá y empreçâ, pa que nadie çienta un êppeçiâh bínculo por una ubicaçión determiná, açí que bamô librê, errantê y deçacopláô.    
+Ola, biembenío y biembenía. Êtta êh la fixa de preçentaçión der grupo locâh de Drupâh Çebiya, una reunión periódica o aleatoria (çegún la época) de perçonâ intereçâh en tó lo que rodea al aprendiçahe y êpperiençiâ con diberçâ tênnolohíâ relaçionâh con [Drupâh](drupal.org) en particulâh: pp, Twîh, Symfony, Compoçêh... nô reunimô en çitiô cambiantê (cá quedá en un lugâh diferente), por aqueyo de deçacoplâh comunidá y empreçâ, pa que nadie çienta un êppeçiâh bínculo por una ubicaçión determiná, açí que bamô librê, errantê y deçacopláô.    
 
 Te recomendamô que pa que puedâ açîttîh, êttêh atento o atenta nuêttrô canalê online pa açêh çegimiento de nuêttrâ quedâh.   
 
@@ -12,18 +30,18 @@ Te recomendamô que pa que puedâ açîttîh, êttêh atento o atenta nuêttrô 
 * [Perfîh der grupo locâh de Drupâh Çebiya en Meetûh](https://www.meetup.com/es-ES/sevilladrupal/)
 * [Perfîh der grupo locâh de Drupâh Çebiya en Drupâh Groups](https://groups.drupal.org/sevilla)
 
-Por çierto, en Drupâh Çebiya también creemô en un liderâggo dîttribuío, açí que no tenemô una perçona "rêpponçable", "organiçadora" o argo açí. Cuarquiêh perçona con iniçiatiba puede organiçâh una quedá çi lo deçea, y lô demâh ayudaremô tó lo poçible.Por çi quierê contâttâh, te anotamô argunâ perçonâ que çuelen imbolucrarçe en lâ âttibidadê de Drupâh Çebiya:   
+Por çierto, en Drupâh Çebiya también creemô en un liderâggo dîttribuío, açí que no tenemô una perçona "rêpponçable", "organiçadora" o argo açí. Cuarquiêh perçona con iniçiatiba puede organiçâh una quedá çi lo deçea, y lô demâh ayudaremô tó lo poçible. Por çi quierê contâttâh, te anotamô argunâ perçonâ que çuelen imbolucrarçe en lâ âttibidadê de Drupâh Çebiya:   
 
 - Fran Seva, [@Fran](https://twitter.com/Fran)
 - Leandro Luvigne, [@lluvigne](https://twitter.com/lluvigne) 
 - Leydis Contreras, [@leydisDanCH](https://twitter.com/leydisDanCH)
-- José Antonio R. Carvajal, [raistlinjoe](https://twitter.com/raistlinjoe)
+- José Antonio R. Carvajal, [@raistlinjoe](https://twitter.com/raistlinjoe)
 - David Rodríguez, [@davidjguru](https://twitter.com/davidjguru)
 
 
-Câtteyano / Castellano / Castilian (Spanish from Spain)
+## 2- Câtteyano / Castellano / Castilian (Spanish from Spain)
 --------------------------------------------------------
-Hola, bienvenido y bienvenida. Esta es la ficha de presentación del grupo local de Drupal Sevilla, una reunión periódica o aleatoria (según la época) de personas interesadas en todo lo que rodea al aprendizaje y experiencias con diversas tecnologías relacionadas con Drupal en particular: php, Twig, Symfony, Composer... nos reunimos en sitios cambiantes (cada quedada en un lugar diferente), por aquello de desacoplar comunidad y empresas, para que nadie sienta un especial vínculo por una ubicación determinada, así que vamos libres, errantes y desacoplados. 
+Hola, bienvenido y bienvenida. Esta es la ficha de presentación del grupo local de Drupal Sevilla, una reunión periódica o aleatoria (según la época) de personas interesadas en todo lo que rodea al aprendizaje y experiencias con diversas tecnologías relacionadas con [Drupal](drupal.org) en particular: php, Twig, Symfony, Composer... nos reunimos en sitios cambiantes (cada quedada en un lugar diferente), por aquello de desacoplar comunidad y empresas, para que nadie sienta un especial vínculo por una ubicación determinada, así que vamos libres, errantes y desacoplados. 
 
 Te recomendamos que para que puedas asistir, estés atento o atenta nuestros canales online para hacer seguimiento de nuestras quedadas.   
 
@@ -31,18 +49,18 @@ Te recomendamos que para que puedas asistir, estés atento o atenta nuestros can
 * [Perfil del grupo local de Drupal Sevilla en Meetup](https://www.meetup.com/es-ES/sevilladrupal/)
 * [Perfil del grupo local de Drupal Sevilla en Drupal Groups](https://groups.drupal.org/sevilla)
 
-Por cierto, en Drupal Sevilla también creemos en un liderazgo distribuido, así que no tenemos una persona "responsable", "organizadora" o algo así. Cualquier persona con iniciativa puede organizar una quedada si lo desea, y los demás ayudaremos todo lo posible.Por si quieres contactar, te anotamos algunas personas que suelen involucrarse en las actividades de Drupal Sevilla:   
+Por cierto, en Drupal Sevilla también creemos en un liderazgo distribuido, así que no tenemos una persona "responsable", "organizadora" o algo así. Cualquier persona con iniciativa puede organizar una quedada si lo desea, y los demás ayudaremos todo lo posible. Por si quieres contactar, te anotamos algunas personas que suelen involucrarse en las actividades de Drupal Sevilla:   
 
 - Fran Seva, [@Fran](https://twitter.com/Fran)
 - Leandro Luvigne, [@lluvigne](https://twitter.com/lluvigne) 
 - Leydis Contreras, [@leydisDanCH](https://twitter.com/leydisDanCH)
-- José Antonio R. Carvajal, [raistlinjoe](https://twitter.com/raistlinjoe)
+- José Antonio R. Carvajal, [@raistlinjoe](https://twitter.com/raistlinjoe)
 - David Rodríguez, [@davidjguru](https://twitter.com/davidjguru)
 
 
-Inglêh / Inglés / English
+## 3- Inglêh / Inglés / English
 --------------------------------------------------
-Hello, welcome. This is the presentation card of the local group of Drupal Sevilla, a periodic or random (depending on the time) meeting of people interested in everything that surrounds the learning and experiences with various technologies related to Drupal in particular: php, Twig, Symfony, Composer ... we meet in changing sites (each staying in a different place), for that of decoupling community and business, so that no one feels a special bond for a particular location, so we're going free, wandering and decoupled. 
+Hello, welcome. This is the presentation card of the local group of Drupal Sevilla, a periodic or random (depending on the time) meeting of people interested in everything that surrounds the learning and experiences with various technologies related to [Drupal](drupal.org) in particular: php, Twig, Symfony, Composer ... we meet in changing sites (each staying in a different place), for that of decoupling community and business, so that no one feels a special bond for a particular location, so we're going free, wandering and decoupled. 
 
 We recommend that in order for you to attend, you should be attentive to our online channels to follow up on our stays.   
 
@@ -50,10 +68,10 @@ We recommend that in order for you to attend, you should be attentive to our onl
 * [Profile of the local Seville Drupal group at Meetup](https://www.meetup.com/es-ES/sevilladrupal/)
 * [Profile of the local Drupal Sevilla group in Drupal Groups](https://groups.drupal.org/sevilla)
 
-By the way, at Drupal Sevilla we also believe in a distributed leadership model, so we don't have a "responsible person" or "leader", "organizer" or something like that. Any person with initiative can organize a meeting if they wish, and the rest of us will help as much as possible:   
+By the way, at Drupal Sevilla we also believe in a distributed leadership model, so we don't have a "responsible person" or "leader", "organizer" or something like that. Any person with initiative can organize a meeting if they wish, and the rest of us will help as much as possible. In case you want to contact us, here are some people who are usually involved in Drupal Sevilla activities:    
 
 - Fran Seva, [@Fran](https://twitter.com/Fran)
 - Leandro Luvigne, [@lluvigne](https://twitter.com/lluvigne) 
 - Leydis Contreras, [@leydisDanCH](https://twitter.com/leydisDanCH)
-- José Antonio R. Carvajal, [raistlinjoe](https://twitter.com/raistlinjoe)
+- José Antonio R. Carvajal, [@raistlinjoe](https://twitter.com/raistlinjoe)
 - David Rodríguez, [@davidjguru](https://twitter.com/davidjguru)


### PR DESCRIPTION
This adds a new introductory paragraph to avoid direct rendering of H1 - Hn titles in the Home view.
**Note:** There's nothing unusual about this commit.   :-P 